### PR TITLE
fix(framework) registration errors

### DIFF
--- a/server/sv_property.lua
+++ b/server/sv_property.lua
@@ -14,10 +14,10 @@ function Property:new(propertyData)
     self.property_id = tostring(propertyData.property_id)
     self.propertyData = propertyData
 
-    local stash = string.format("property_%s", propertyData.property_id)
+    local stashName = string.format("property_%s", propertyData.property_id)
     local stashConfig = Config.Shells[propertyData.shell].stash
 
-    Framework[Config.Inventory].RegisterInventory(stash, stashConfig, propertyData.street)
+    Framework[Config.Inventory].RegisterInventory(stashName, propertyData.street or propertyData.apartment or stashName, stashConfig)
 
     return self
 end

--- a/shared/framework.lua
+++ b/shared/framework.lua
@@ -15,6 +15,14 @@ if IsDuplicityVersion() then
         TriggerClientEvent('QBCore:Notify', src, message, type)
     end
 
+    function Framework.ox.RegisterInventory(stash, label, stashConfig)
+        exports.ox_inventory:RegisterStash(stash, label, stashConfig.slots, stashConfig.maxweight, nil)
+    end
+
+    function Framework.qb.RegisterInventory(stash, label, stashConfig)
+        -- Used for ox_inventory compat
+    end
+
     return
 end
 
@@ -217,10 +225,6 @@ Framework.qb = {
         TriggerServerEvent("inventory:server:OpenInventory", "stash", stash, stashConfig)
         TriggerEvent("inventory:client:SetCurrentStash", stash)
     end,
-
-    RegisterInventory = function (stash, stashConfig, label)
-        -- Used for ox_inventory compat
-    end,
 }
 
 Framework.ox = {
@@ -397,9 +401,5 @@ Framework.ox = {
 
     OpenInventory = function (stash, stashConfig)
         exports.ox_inventory:openInventory('stash', stash)
-    end,
-
-    RegisterInventory = function (stash, stashConfig, label)
-        exports.ox_inventory:RegisterStash(stash, label, stashConfig.slots, stashConfig.maxweight, nil)
     end,
 }


### PR DESCRIPTION
I have edited the registration, tested with 3 chars and 0 issues. 

Tested this on a clean qb-core server with qb-inventory and have tested this on an qb-core server with only ox_inventory added.
I have found no issues except I needed to rejoin once to get my apartments to show up (qb-spawn issue propably, since I only had this on the qb-inventory version)

I'm sorry Xirvin, please forgive me