### PR TITLE
Changed from ox_lib notify to Framework[Config.Notify].Notify.

### DIFF
--- a/server/sv_property.lua
+++ b/server/sv_property.lua
@@ -694,7 +694,7 @@ RegisterNetEvent("ps-housing:server:removeAccess", function(property_id, citizen
 
     if not property.propertyData.owner == citizenid then
         -- hacker ban or something
-        TriggerClientEvent("ox_lib:notify", src, {title="You are not the owner of this property!", type="error"})
+        Framework[Config.Notify].Notify(src, "You are not the owner of this property!", "error")
         return
     end
 


### PR DESCRIPTION
# Overview
It's supposed to be Framework[Config.Notify].Notify and not ox_lib notify.

# Testing Steps

- [YES] Did you test the changes you made?
- [YES] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [YES] Did you test your changes in multiplayer to ensure it works correctly on all clients?
