### PR TITLE
Doorlock addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,8 +362,8 @@ RegisterNetEvent('qb-doorlock:client:addNewDoorPS', function()
 	else
 		local result, entityHit
 		local entity, coords, heading, model = {0, 0}, {0, 0}, {0, 0}, {0, 0}
+		QBCore.Functions.Notify("Use this on Door's only!", 'error', 10000)
 		for i = 1, 2 do
-			QBCore.Functions.Notify("Use this on Door's only!", 'error', 10000)
 			while true do
 				exports['qb-core']:DrawText("Press [Right Click] at the Door. Press [E] to confirm it.",'left')
 				result, entityHit = GetEntityPlayerIsFreeAimingAt(PlayerId())
@@ -378,9 +378,12 @@ RegisterNetEvent('qb-doorlock:client:addNewDoorPS', function()
 				if entity[i] and IsControlPressed(0, 38) then break end
 				Wait(0)
 			end
-			exports['qb-core']:HideText()
+			if entity[1] == entityHit then
+				QBCore.Functions.Notify("Set the next door!", 'primary', 4000)
+			end
 			Wait(200)
 		end
+		exports['qb-core']:HideText()
 		SetEntityDrawOutline(entity[1], false)
 		SetEntityDrawOutline(entity[2], false)
 		if not model[1] or model[1] == 0 or not model[2] or model[2] == 0 then QBCore.Functions.Notify(Lang:t("error.door_not_found"), 'error') return end

--- a/README.md
+++ b/README.md
@@ -327,22 +327,22 @@ RegisterNetEvent('qb-doorlock:client:addNewDoorPS', function()
 	if doorData.doortype == 'door' or doorData.doortype == 'sliding' or doorData.doortype == 'garage' then
 		local heading, result, entityHit
 		local entity, coords, model = 0, 0, 0
-		QBCore.Functions.Notify("Point any Weapon at the Door. Press [E] to confirm it.", 'primary', 30000)
+		QBCore.Functions.Notify("Use this on Door's only!", 'error', 10000)
 		while true do
-			if IsPlayerFreeAiming(PlayerId()) then
-				result, entityHit = raycastWeapon()
-				if result and entityHit ~= entity then
-					SetEntityDrawOutline(entity, false)
-					SetEntityDrawOutline(entityHit, true)
-					entity = entityHit
-					coords = GetEntityCoords(entity)
-					model = GetEntityModel(entity)
-					heading = GetEntityHeading(entity)
-				end
-				if entity and IsControlPressed(0, 38) then break end
+			exports['qb-core']:DrawText("Press [Right Click] at the Door. Press [E] to confirm it.",'left')
+			result, entityHit = GetEntityPlayerIsFreeAimingAt(PlayerId())
+			if result and entityHit ~= entity then
+				SetEntityDrawOutline(entity, false)
+				SetEntityDrawOutline(entityHit, true)
+				entity = entityHit
+				coords = GetEntityCoords(entity)
+				model = GetEntityModel(entity)
+				heading = GetEntityHeading(entity)
 			end
+			if entity and IsControlPressed(0, 38) then break end
 			Wait(0)
 		end
+		exports['qb-core']:HideText()
 		SetEntityDrawOutline(entity, false)
 		if not model or model == 0 then QBCore.Functions.Notify(Lang:t("error.door_not_found"), 'error') canContinue = true return end
 		result = DoorSystemFindExistingDoor(coords.x, coords.y, coords.z, model)
@@ -363,22 +363,22 @@ RegisterNetEvent('qb-doorlock:client:addNewDoorPS', function()
 		local result, entityHit
 		local entity, coords, heading, model = {0, 0}, {0, 0}, {0, 0}, {0, 0}
 		for i = 1, 2 do
-			QBCore.Functions.Notify("Point any Weapon at the Door. Press [E] to confirm it.", 'primary', 30000)
+			QBCore.Functions.Notify("Use this on Door's only!", 'error', 10000)
 			while true do
-				if IsPlayerFreeAiming(PlayerId()) then
-					result, entityHit = raycastWeapon()
-					if result and entityHit ~= entity[i] then
-						SetEntityDrawOutline(entity[i], false)
-						SetEntityDrawOutline(entityHit, true)
-						entity[i] = entityHit
-						coords[i] = GetEntityCoords(entity[i])
-						model[i] = GetEntityModel(entity[i])
-						heading[i] = GetEntityHeading(entity[i])
-					end
-					if entity[i] and IsControlPressed(0, 38) then break end
+				exports['qb-core']:DrawText("Press [Right Click] at the Door. Press [E] to confirm it.",'left')
+				result, entityHit = GetEntityPlayerIsFreeAimingAt(PlayerId())
+				if result and entityHit ~= entity[i] then
+					SetEntityDrawOutline(entity[i], false)
+					SetEntityDrawOutline(entityHit, true)
+					entity[i] = entityHit
+					coords[i] = GetEntityCoords(entity[i])
+					model[i] = GetEntityModel(entity[i])
+					heading[i] = GetEntityHeading(entity[i])
 				end
+				if entity[i] and IsControlPressed(0, 38) then break end
 				Wait(0)
 			end
+			exports['qb-core']:HideText()
 			Wait(200)
 		end
 		SetEntityDrawOutline(entity[1], false)

--- a/README.md
+++ b/README.md
@@ -303,14 +303,15 @@ RegisterNetEvent('qb-doorlock:client:addNewDoorPS', function()
 	doorData = dialog
 
 	local propertyId = exports['ps-housing']:GetPropertyId()
-	local randomchars = generateRandomString("4")
-	local uniqueid = "propertyid_" ..propertyId.. "_door_" ..randomchars
+	local randomChars = generateRandomString("4")
+	local uniqueId = "propertyid_" ..propertyId.. "_door_" ..randomChars
+
 	doorData.configfile = "PS ( " ..PlayerData.citizenid.. " )"
-	doorData.dooridentifier = uniqueid
-	doorData.doorlabel = uniqueid
+	doorData.dooridentifier = uniqueId
+	doorData.doorlabel = uniqueId
 	doorData.cid = PlayerData.citizenid
 	doorData.locked = 'true'
-	doorData.distance = "2"
+	doorData.distance = 2
 
 	local identifier = doorData.configfile..' - '..doorData.dooridentifier
 	if Config.DoorList[identifier] then
@@ -319,21 +320,13 @@ RegisterNetEvent('qb-doorlock:client:addNewDoorPS', function()
 		return
 	end
 
-	if doorData.configfile == '' then doorData.configfile = false end
-	if doorData.job == '' then doorData.job = false end
-	if doorData.gang == '' then doorData.gang = false end
-	if doorData.cid == '' then doorData.cid = false end
-	if doorData.item == '' then doorData.item = false end
-	if doorData.doorlabel == '' then doorData.doorlabel = nil end
 	if doorData.pickable ~= 'true' then doorData.pickable = nil end
 	if doorData.cantunlock ~= 'true' then doorData.cantunlock = nil end
 	if doorData.hidelabel ~= 'true' then doorData.hidelabel = nil end
 
-	doorData.locked = 'true'
-	doorData.distance = tonumber(doorData.distance)
 	if doorData.doortype == 'door' or doorData.doortype == 'sliding' or doorData.doortype == 'garage' then
 		local heading, result, entityHit
-		local entity, coords, model= 0, 0, 0
+		local entity, coords, model = 0, 0, 0
 		QBCore.Functions.Notify("Point any Weapon at the Door. Press [E] to confirm it.", 'primary', 30000)
 		while true do
 			if IsPlayerFreeAiming(PlayerId()) then

--- a/client/cl_property.lua
+++ b/client/cl_property.lua
@@ -1,3 +1,5 @@
+currentPropertyId = nil
+
 Property = {
     property_id = nil,
     propertyData = nil,
@@ -213,6 +215,8 @@ function Property:EnterShell()
 
     self:GiveMenus()
 
+    currentPropertyId = self.property_id
+    
     Wait(250)
     DoScreenFadeIn(250)
 end
@@ -249,6 +253,9 @@ function Property:LeaveShell()
     self.doorbellPool = {}
 
     self.inProperty = false
+
+    currentPropertyId = nil
+    
     Wait(250)
     DoScreenFadeIn(250)
 end
@@ -269,6 +276,19 @@ function Property:GiveMenus()
             "ps-housing:client:openFurnitureMenu",
             { propertyId = self.property_id }
         )
+        
+        if Config.Doorlock == "qb" then 
+            Framework[Config.Radial].AddRadialOption(
+                "new_doorlock",
+                "Add Doorlock",
+                "door-open",
+                function()
+                end,
+                "qb-doorlock:client:addNewDoorPS"
+            )
+        else
+            --SOON <3
+        end
     end
 
     if self.owner then
@@ -289,6 +309,7 @@ function Property:RemoveMenus()
     if not self.inProperty then return end
 
     Framework[Config.Radial].RemoveRadialOption("furniture_menu")
+    Framework[Config.Radial].RemoveRadialOption("new_doorlock")
 
     if self.owner then
         Framework[Config.Radial].RemoveRadialOption("access_menu")

--- a/client/client.lua
+++ b/client/client.lua
@@ -82,6 +82,10 @@ exports('GetProperty', function(property_id)
     return Property.Get(property_id)
 end)
 
+exports("GetPropertyId", function()
+    return currentPropertyId
+end)
+
 exports('GetApartments', function()
     return ApartmentsTable
 end)

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -11,6 +11,7 @@ Config.Target = "ox" -- "ox" or "qb"
 Config.Notify = "ox" -- "ox" or "qb"
 Config.Radial = "ox" -- "ox" or "qb"
 Config.Inventory = "ox" -- "ox" or "qb"
+Config.Doorlock = "ox" -- "ox" or "qb"
 
 -- Anyone provided with keys to a property has the ability to modify its furnishings.
 Config.AccessCanEditFurniture = true


### PR DESCRIPTION
# Overview
*What is did is creating a new Event inside qb-doorlock to manage the addition to lock doors inside your shell ( owner only )*

# Details
- in cl_property i added: new variable currentPropertyId which sets the propertyid if im inside a property, if not its nil
- in client.lua i added: the new export which returns the value above
- in README.md i added: Step 11 which is OPTIONAL 
- in config.lua i added: Config.Doorlock to choose between qb-doorlock or ox-doorlock(not implemented yet)

# UI Changes / Functionality
https://youtu.be/oUvn6G5uH0c  ///  NEW VERSION: https://youtu.be/OrFa-f3D9FY

# Testing Steps
*Go inside a property and check your radialmenu.*

- [YES] Did you test the changes you made?
- [KINDA] Did you test core functionality of the script to ensure your changes do not regress other areas?
 i did test the qb-radialmenu site, not the ox-radialmenu site
- [NO] Did you test your changes in multiplayer to ensure it works correctly on all clients?
