### PR TITLE
Fix Issue Taking Payment For Furniture

### DIFF
--- a/server/sv_property.lua
+++ b/server/sv_property.lua
@@ -593,9 +593,9 @@ RegisterNetEvent("ps-housing:server:buyFurniture", function(property_id, items, 
     end
 
     if price > PlayerData.money.bank then
-        Player.Functions.RemoveMoney('bank', price, "Bought furniture")
-    else
         Player.Functions.RemoveMoney('cash', price, "Bought furniture")
+    else
+        Player.Functions.RemoveMoney('bank', price, "Bought furniture")
     end
 
     local numFurnitures = #property.propertyData.furnitures

--- a/server/sv_property.lua
+++ b/server/sv_property.lua
@@ -592,7 +592,7 @@ RegisterNetEvent("ps-housing:server:buyFurniture", function(property_id, items, 
         return
     end
 
-    if price > PlayerData.money.bank then
+    if price <= PlayerData.money.cash then
         Player.Functions.RemoveMoney('cash', price, "Bought furniture")
     else
         Player.Functions.RemoveMoney('bank', price, "Bought furniture")


### PR DESCRIPTION
# Overview
You can get free furniture currently if you have enough money in your bank to pay for the cart, but not enough cash.

# Details
The code in `sv_property.lua`  `ps-housing:server:buyFurniture` checks to make sure they either have enough cash or enough in their bank to pay for the furniture. However when it comes to taking the payment it checks if the cost is greater than the bank amount and, instead of reducing the amount of cash the player has, it tries to remove the money from the player's bank still. This means that if the settings for QBCore are to not allow negative cash and the player has enough in their bank account for the furniture and but not enough cash, it will try to take cash unsuccessfully and give them the furniture for free.

# UI Changes / Functionality
N/A

# Testing Steps
Before the change : 
- Make sure QB is set up to not allow negative cash (`qb-core/config.lua` `QBConfig.Money.DontAllowMinus = { 'cash', 'crypto' }`)
- Have no cash on your character, but plenty in the bank
- Purchase furniture and note that no money is taken

After the change : 
- Make sure QB is set up to not allow negative cash (`qb-core/config.lua` `QBConfig.Money.DontAllowMinus = { 'cash', 'crypto' }`)
- Have no cash on your character, but plenty in the bank
- Purchase furniture and note that money is now taken from your bank


- [x] Did you test the changes you made?
- [x] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [x] Did you test your changes in multiplayer to ensure it works correctly on all clients?
