### PR TITLE
Stop treating arrays as if they are tables

### DIFF
--- a/client/cl_property.lua
+++ b/client/cl_property.lua
@@ -489,11 +489,11 @@ function Property:UnloadFurniture(furniture, index)
     end
 
     if index and self.furnitureObjs?[index] then
-        self.furnitureObjs[index] = nil
+        table.remove(self.furnitureObjs, index)
     else 
         for i = 1, #self.furnitureObjs do
             if self.furnitureObjs[i].id == furniture.id then
-                self.furnitureObjs[i] = nil
+                table.remove(self.furnitureObjs, i)
                 break
             end
         end

--- a/server/server.lua
+++ b/server/server.lua
@@ -10,6 +10,7 @@ MySQL.ready(function()
         end
         for _, v in pairs(result) do
             local id = tostring(v.property_id)
+            local furnitures = string.gsub(tostring(v.furnitures), "null,", "") -- Remove nulls for properties that were shagged before the fix went in
             local propertyData = {
                 property_id = tostring(id),
                 owner = v.owner_citizenid,
@@ -18,7 +19,7 @@ MySQL.ready(function()
                 description = v.description,
                 has_access = json.decode(v.has_access),
                 extra_imgs = json.decode(v.extra_imgs),
-                furnitures = json.decode(v.furnitures),
+                furnitures = json.decode(furnitures),
                 for_sale = v.for_sale,
                 price = v.price,
                 shell = v.shell,

--- a/server/sv_property.lua
+++ b/server/sv_property.lua
@@ -624,7 +624,7 @@ RegisterNetEvent("ps-housing:server:removeFurniture", function(property_id, item
 
     for k, v in pairs(currentFurnitures) do
         if v.id == itemid then
-            currentFurnitures[k] = nil
+            table.remove(currentFurnitures, k)
             break
         end
     end


### PR DESCRIPTION
# Overview
When removing items, it would cause you to have nulls in the decoded json string for furniture.

# Details
Using table.remove rather than table[index] = nil preserves the objects status as a Lua array.

# UI Changes / Functionality
N/A

# Testing Steps
- Remove a placed furniture item
- Check for errors relating to nil objects

- [ ] Did you test the changes you made?
- [ ] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [ ] Did you test your changes in multiplayer to ensure it works correctly on all clients?
