### PR TITLE
fixed shells rotating to door heading

### DIFF
--- a/client/cl_property.lua
+++ b/client/cl_property.lua
@@ -77,7 +77,7 @@ function Property:CreateShell()
     local coords = self:GetDoorCoords()
 
     coords = vec3(coords.x, coords.y, coords.z - 25.0)
-    self.shell = Shell:CreatePropertyShell(self.propertyData.shell, coords, self.shellData.doorOffset.h)
+    self.shell = Shell:CreatePropertyShell(self.propertyData.shell, coords)
 
     self.shellObj = self.shell.entity
 


### PR DESCRIPTION
# Overview
Currently, Shells are being rotated to the side because the shell maker is getting the door heading offset as the rotation arg.

# Testing Steps

Before my change:

![FiveM_b2802_GTAProcess_nWBp78TKsO](https://github.com/Project-Sloth/ps-housing/assets/74205343/321c6417-6540-4b7a-8334-e3b250d5e83f)

After my changes, the shells are back to normal rotation.

- [x] Did you test the changes you made?
- [x] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [x] Did you test your changes in multiplayer to ensure it works correctly on all clients?
