### PR TITLE
Qb weed addition

### DIFF
--- a/client/cl_property.lua
+++ b/client/cl_property.lua
@@ -208,6 +208,9 @@ function Property:EnterShell()
     self:CreateShell()
 
     self:LoadFurnitures()
+    if Config.QBWeed then
+        TriggerEvent('qb-weed:client:getHousePlants', self.property_id)
+    end
 
     self:GiveMenus()
 
@@ -228,6 +231,9 @@ function Property:LeaveShell()
 
     self:UnloadFurnitures()
     self.propertyData.furnitures = {}
+    if Config.QBWeed then
+        TriggerEvent('qb-weed:client:leaveHouse')
+    end
 
     self.shell:DespawnShell()
     self.shell = nil

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -13,6 +13,9 @@ Config.Radial = "ox" -- "ox" or "qb"
 Config.Inventory = "qb" -- "ox" or "qb"
 Config.Logs = "qb" -- "qb"
 
+-- Set this value to true if ur using qb-weed 
+Config.QBWeed = true
+
 -- Anyone provided with keys to a property has the ability to modify its furnishings.
 Config.AccessCanEditFurniture = true
 


### PR DESCRIPTION
# Overview
*ps-housing does not come with qb-weed addition*

# Details
- added config option to activate/deactivate
- added events in cl_property.lua

# UI Changes / Functionality
https://youtu.be/d-fjSVrNce8

# Testing Steps
*Create a House and go inside, then give yourself any weed seed item and then place it inside your house.*

- [YES] Did you test the changes you made?
- [YES] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [NO] Did you test your changes in multiplayer to ensure it works correctly on all clients?
