### PR TITLE
Optimizations + Stop murdering of server

### DIFF
--- a/client/cl_property.lua
+++ b/client/cl_property.lua
@@ -32,8 +32,7 @@ function Property:new(propertyData)
     propertyData.furnitures = {}
     self.propertyData = propertyData
 
-    local Player = QBCore.Functions.GetPlayerData()
-    local citizenid = Player.citizenid
+    local citizenid = PlayerData.citizenid
 
     self.owner = propertyData.owner == citizenid
     self.has_access = lib.table.contains(self.propertyData.has_access, citizenid)
@@ -630,8 +629,7 @@ end
 function Property:UpdateOwner(newOwner)
     self.propertyData.owner = newOwner
 
-    local Player = QBCore.Functions.GetPlayerData()
-    local citizenid = Player.citizenid
+    local citizenid = PlayerData.citizenid
 
     self.owner = newOwner == citizenid
 
@@ -660,8 +658,7 @@ function Property:UpdateDoor(newDoor, newStreet, newRegion)
 end
 
 function Property:UpdateHas_access(newHas_access)
-    local Player = QBCore.Functions.GetPlayerData()
-    local citizenid = Player.citizenid
+    local citizenid = PlayerData.citizenid
     self.propertyData.has_access = newHas_access
     self.has_access = lib.table.contains(newHas_access, citizenid)
 

--- a/client/client.lua
+++ b/client/client.lua
@@ -16,7 +16,7 @@ RegisterNetEvent('ps-housing:client:removeProperty', function (property_id)
 	PropertiesTable[property_id] = nil
 end)
 
-function InitialiseProperties()
+function InitialiseProperties(properties)
     Debug("Initialising properties")
     PlayerData = QBCore.Functions.GetPlayerData()
 
@@ -24,8 +24,10 @@ function InitialiseProperties()
         ApartmentsTable[k] = Apartment:new(v)
     end
 
-    local properties = lib.callback.await('ps-housing:server:requestProperties')
-
+	if not properties then
+    	properties = lib.callback.await('ps-housing:server:requestProperties')
+	end
+	
     for k, v in pairs(properties) do
         createProperty(v.propertyData)
     end
@@ -45,20 +47,6 @@ end)
 
 RegisterNetEvent('QBCore:Client:OnJobUpdate', function(job)
     PlayerData.job = job
-end)
-
-RegisterNetEvent('ps-housing:client:liveRestart', function(properties)
-    for k, v in pairs(Config.Apartments) do
-        ApartmentsTable[k] = Apartment:new(v)
-    end
-
-    for k, v in pairs(properties) do
-        createProperty(v.propertyData)
-    end
-
-    TriggerEvent("ps-housing:client:initialisedProperties")
-    PlayerData = QBCore.Functions.GetPlayerData()
-    Debug("Initialised properties")
 end)
 
 RegisterNetEvent('ps-housing:client:setupSpawnUI', function(cData)

--- a/client/client.lua
+++ b/client/client.lua
@@ -1,4 +1,5 @@
 QBCore = exports['qb-core']:GetCoreObject()
+PlayerData = {}
 
 local function createProperty(property)
 	PropertiesTable[property.property_id] = Property:new(property)
@@ -17,6 +18,8 @@ end)
 
 function InitialiseProperties()
     Debug("Initialising properties")
+    PlayerData = QBCore.Functions.GetPlayerData()
+
     for k, v in pairs(Config.Apartments) do
         ApartmentsTable[k] = Apartment:new(v)
     end
@@ -38,6 +41,24 @@ AddEventHandler("onResourceStart", function(resourceName) -- Used for when the r
 	if (GetCurrentResourceName() == resourceName) then
         InitialiseProperties()
 	end
+end)
+
+RegisterNetEvent('QBCore:Client:OnJobUpdate', function(job)
+    PlayerData.job = job
+end)
+
+RegisterNetEvent('ps-housing:client:liveRestart', function(properties)
+    for k, v in pairs(Config.Apartments) do
+        ApartmentsTable[k] = Apartment:new(v)
+    end
+
+    for k, v in pairs(properties) do
+        createProperty(v.propertyData)
+    end
+
+    TriggerEvent("ps-housing:client:initialisedProperties")
+    PlayerData = QBCore.Functions.GetPlayerData()
+    Debug("Initialised properties")
 end)
 
 RegisterNetEvent('ps-housing:client:setupSpawnUI', function(cData)

--- a/client/modeler.lua
+++ b/client/modeler.lua
@@ -439,7 +439,7 @@ Modeler = {
             totalPrice = totalPrice + v.price
         end
 
-        local PlayerData = QBCore.Functions.GetPlayerData()
+        PlayerData = QBCore.Functions.GetPlayerData()
         if PlayerData.money.cash < totalPrice and PlayerData.money.bank < totalPrice then
 	    Framework[Config.Notify].Notify("You don't have enough money!", "error")
             return

--- a/server/server.lua
+++ b/server/server.lua
@@ -125,7 +125,7 @@ AddEventHandler("onResourceStart", function(resourceName) -- Used for when the r
             Wait(100)
         end
         TriggerClientEvent('ps-housing:client:liveRestart', -1, PropertiesTable)
-	end
+	end 
 end)
 
 RegisterNetEvent("ps-housing:server:createNewApartment", function(aptLabel)

--- a/server/server.lua
+++ b/server/server.lua
@@ -124,7 +124,7 @@ AddEventHandler("onResourceStart", function(resourceName) -- Used for when the r
         while not dbloaded do
             Wait(100)
         end
-        TriggerClientEvent('ps-housing:client:liveRestart', -1, PropertiesTable)
+        TriggerClientEvent('ps-housing:client:initialiseProperties', -1, PropertiesTable)
 	end 
 end)
 

--- a/server/server.lua
+++ b/server/server.lua
@@ -119,6 +119,15 @@ AddEventHandler("ps-housing:server:updateProperty", function(type, property_id, 
     property[type](property, data)
 end)
 
+AddEventHandler("onResourceStart", function(resourceName) -- Used for when the resource is restarted while in game
+	if (GetCurrentResourceName() == resourceName) then
+        while not dbloaded do
+            Wait(100)
+        end
+        TriggerClientEvent('ps-housing:client:liveRestart', -1, PropertiesTable)
+	end
+end)
+
 RegisterNetEvent("ps-housing:server:createNewApartment", function(aptLabel)
     local src = source
     if not Config.StartingApartment then return end

--- a/shared/framework.lua
+++ b/shared/framework.lua
@@ -90,7 +90,6 @@ Framework.qb = {
                         icon = "fas fa-eye",
                         action = showcase,
                         canInteract = function()
-                            local PlayerData = QBCore.Functions.GetPlayerData()
                             local job = PlayerData.job
                             local jobName = job.name
                             local onDuty = job.onduty
@@ -102,7 +101,6 @@ Framework.qb = {
                         icon = "fas fa-circle-info",
                         action = showData,
                         canInteract = function()
-                            local PlayerData = QBCore.Functions.GetPlayerData()
                             local job = PlayerData.job
                             local jobName = job.name
                             local onDuty = job.onduty
@@ -123,7 +121,6 @@ Framework.qb = {
                         icon = "fas fa-building-shield",
                         action = raid,
                         canInteract = function()
-                            local PlayerData = QBCore.Functions.GetPlayerData()
                             local job = PlayerData.job
                             local jobName = job.name
                             local gradeAllowed = tonumber(job.grade.level) >= Config.MinGradeToRaid
@@ -167,7 +164,6 @@ Framework.qb = {
                     action = seeAllToRaid,
                     icon = "fas fa-building-shield",
                     canInteract = function()
-                        local PlayerData = QBCore.Functions.GetPlayerData()
                         local job = PlayerData.job
                         local jobName = job.name
                         local gradeAllowed = tonumber(job.grade.level) >= Config.MinGradeToRaid
@@ -318,7 +314,6 @@ Framework.ox = {
                         -- local property = Property.Get(property_id)
                         -- if property.propertyData.owner ~= nil then return false end -- if its owned, it cannot be showcased
                         
-                        local PlayerData = QBCore.Functions.GetPlayerData()
                         local job = PlayerData.job
                         local jobName = job.name
 
@@ -330,7 +325,6 @@ Framework.ox = {
                     icon = "fas fa-circle-info",
                     onSelect = showData,
                     canInteract = function()
-                        local PlayerData = QBCore.Functions.GetPlayerData()
                         local job = PlayerData.job
                         local jobName = job.name
                         local onDuty = job.onduty
@@ -351,7 +345,6 @@ Framework.ox = {
                     icon = "fas fa-building-shield",
                     onSelect = raid,
                     canInteract = function()
-                        local PlayerData = QBCore.Functions.GetPlayerData()
                         local job = PlayerData.job
                         local jobName = job.name
                         local gradeAllowed = tonumber(job.grade.level) >= Config.MinGradeToRaid
@@ -392,7 +385,6 @@ Framework.ox = {
                     onSelect = seeAllToRaid,
                     icon = "fas fa-building-shield",
                     canInteract = function()
-                        local PlayerData = QBCore.Functions.GetPlayerData()
                         local job = PlayerData.job
                         local jobName = job.name
                         local gradeAllowed = tonumber(job.grade.level) >= Config.MinGradeToRaid


### PR DESCRIPTION
# Overview
Stops spamming of GetPlayerData() constantly 

# Details
Stops spamming of GetPlayerData() constantly in favor of simply getting the data on load in and updating the job via event. Also when restarting of the script live instead of making every client request the data from the server we just send it out to every client reducing the hitch on restart with lots of properties. We have around 200 properties and this would cause a 1.5-2 second hitch on load in for players. This removes that hitch or reduces it to about 250-300ms which is way more manageable.

# UI Changes / Functionality
None

# Testing Steps
We ran beta tests with 5-6 people the other night. *Some* formatting changes were made so hopefully there are no syntax errors. Approximately 200 properties are loaded via data. 

- [x] Did you test the changes you made?
- [x] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [x] Did you test your changes in multiplayer to ensure it works correctly on all clients?
