### PR TITLE
Correct Trigger and Garagezone

### DIFF
--- a/client/cl_property.lua
+++ b/client/cl_property.lua
@@ -180,7 +180,7 @@ function Property:RegisterGarageZone()
     self.garageZone = lib.zones.box({
         coords = vec3(garageData.x, garageData.y, garageData.z),
         size = vector3(garageData.length + 5.0, garageData.width + 5.0, 3.5),
-        rotation = rotation = garageData.h,
+        rotation = garageData.h,
         debug = Config.DebugMode,
         onEnter = function()
             TriggerEvent('qb-garages:client:setHouseGarage', self.property_id, true)

--- a/client/cl_property.lua
+++ b/client/cl_property.lua
@@ -180,7 +180,7 @@ function Property:RegisterGarageZone()
     self.garageZone = lib.zones.box({
         coords = vec3(garageData.x, garageData.y, garageData.z),
         size = vector3(garageData.length + 5.0, garageData.width + 5.0, 3.5),
-        rotation = 45,
+        rotation = rotation = garageData.h,
         debug = Config.DebugMode,
         onEnter = function()
             TriggerEvent('qb-garages:client:setHouseGarage', self.property_id, true)


### PR DESCRIPTION
# Overview
*This PR changes the rotation of the trigger zone to make sure its the same as the garagezone*

# Details
*Changed the rotation of the trigger zone so it matches the garage zone, default was 45 degress, should be like the garage zone was set.*

# Testing Steps
*Set Debug to true and check the direction of the WHITE box, it should change, not much but it should move so it points in the correct dirrection*

- [YES] Did you test the changes you made?
- [YES] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [NO] Did you test your changes in multiplayer to ensure it works correctly on all clients?

Thanks to OrIoN7531 <3