### PR TITLE
Fix syntax error in sv_property.lua

### DIFF
--- a/server/sv_property.lua
+++ b/server/sv_property.lua
@@ -632,7 +632,7 @@ RegisterNetEvent("ps-housing:server:buyFurniture", function(property_id, items, 
 
     Framework[Config.Notify].Notify(src, "You bought furniture for $" .. price, "success")
 
-    Framework[Config.Logs].SendLog("**Player ".. GetPlayerName(src) .. "** bought furniture for **$" .. price"**")
+    Framework[Config.Logs].SendLog("**Player ".. GetPlayerName(src) .. "** bought furniture for **$" .. price .. "**")
 
     Debug("Player bought furniture for $" .. price, "by: " .. GetPlayerName(src))
 end)


### PR DESCRIPTION
# Overview
When ps-housing tries to log a furniture purchase, the log errors out -
`@ps-housing/server/sv_property.lua:632: attempt to call a number value (local 'price')`

# Details
It's a syntax error.

# UI Changes / Functionality
No more error in the server logs.

# Testing Steps

- [YES] Did you test the changes you made?
- [YES] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [NO] Did you test your changes in multiplayer to ensure it works correctly on all clients?
