### PR TITLE
Added ox_inventory support for raid

### DIFF
--- a/server/sv_property.lua
+++ b/server/sv_property.lua
@@ -547,8 +547,12 @@ RegisterNetEvent('ps-housing:server:raidProperty', function(property_id)
                 -- Remove the "stormram" item from the officer's inventory
                 if stormRamIndex then
                     table.remove(PlayerData.items, stormRamIndex)
-                    TriggerClientEvent("inventory:client:ItemBox", src, QBCore.Shared.Items["police_stormram"], "remove")
-                    TriggerEvent("inventory:server:RemoveItem", src, "police_stormram", 1)
+                    if Config.Inventory == 'ox' then
+                        exports.ox_inventory:RemoveItem(src, 'police_stormram', 1)
+                    else
+                        TriggerClientEvent("inventory:client:ItemBox", src, QBCore.Shared.Items["police_stormram"], "remove")
+                        TriggerEvent("inventory:server:RemoveItem", src, "police_stormram", 1)
+                    end
                 end
             end
         else


### PR DESCRIPTION
# Overview
Added option to have ox_inventory removeitem. If you have qb in config as inventory it will use the previous code.

- [YES] Did you test the changes you made?
- [YES] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [YES] Did you test your changes in multiplayer to ensure it works correctly on all clients?
