### PR TITLE
Fixed MySQL query

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -84,10 +84,14 @@ AddEventHandler("ps-housing:server:registerProperty", function (propertyData) --
 
         Wait(1000)
 
-        local appearance = MySQL.query.await("SELECT skin FROM playerskins WHERE citizenid = ?", {propertyData.owner})
-        if not appearance then
+        local query = "SELECT skin FROM playerskins WHERE citizenid = ?"
+        local result = MySQL.Sync.fetchAll(query, {propertyData.owner})
+
+        if result and result[1] then
+            Debug("Player: " .. propertyData.owner .. " skin already exists!")
+        else
             TriggerClientEvent("qb-clothes:client:CreateFirstCharacter", src)
-            Debug("Player: "..propertyData.owner.." is creating a new character!")
+            Debug("Player: " .. propertyData.owner .. " is creating a new character!")
         end
 
         Framework[Config.Notify].Notify(src, "Open radial menu for furniture menu and place down your stash and clothing locker.", "info")


### PR DESCRIPTION
# Overview
There was an issue with PR #96 that would not allow the server to give a clothing menu to the player on new character creation. This fix works the same way but ensures the SQL is called correctly.

# Details
See Above

# UI Changes / Functionality
Not Applicable

# Testing Steps
Create a new character, Register, Choose Apartment, Get a clothing menu.

- [YES] Did you test the changes you made?
- [YES] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [YES] Did you test your changes in multiplayer to ensure it works correctly on all clients?
