### PR TITLE
Furniture table element fix

### DIFF
--- a/client/cl_property.lua
+++ b/client/cl_property.lua
@@ -468,12 +468,11 @@ function Property:LoadFurnitures()
 end
 
 function Property:UnloadFurniture(furniture, index)
-    local entity = furniture.entity
-
+    local entity = furniture?.entity
     if not entity then 
         for i = 1, #self.furnitureObjs do
-            if self.furnitureObjs[i].id == furniture.id then
-                entity = self.furnitureObjs[i].entity
+            if self.furnitureObjs[i]?.id and furniture?.id and self.furnitureObjs[i].id == furniture.id then
+                entity = self.furnitureObjs[i]?.entity
                 break
             end
         end
@@ -490,11 +489,11 @@ function Property:UnloadFurniture(furniture, index)
     end
 
     if index and self.furnitureObjs?[index] then
-        self.furnitureObjs[index] = nil
+        table.remove(self.furnitureObjs, index)
     else 
         for i = 1, #self.furnitureObjs do
-            if self.furnitureObjs[i].id == furniture.id then
-                self.furnitureObjs[i] = nil
+            if self.furnitureObjs[i]?.id and furniture?.id and self.furnitureObjs[i].id == furniture.id then
+                table.remove(self.furnitureObjs, i)
                 break
             end
         end

--- a/server/sv_property.lua
+++ b/server/sv_property.lua
@@ -671,7 +671,7 @@ RegisterNetEvent("ps-housing:server:removeFurniture", function(property_id, item
 
     for k, v in pairs(currentFurnitures) do
         if v.id == itemid then
-            currentFurnitures[k] = nil
+            table.remove(currentFurnitures, k)
             break
         end
     end


### PR DESCRIPTION
# Overview
* When removing furniture from the middle of the table setting tbl[i] = nil won't shift elements of the table. This will break calculating table length of the furniture table, encoding will give null elements and will break loops such as ipairs etc. Related to issue #80 (https://streamable.com/fpo9t2)*

# Details
*`table.remove()` will shift elements in the table accordingly rearranging table.*

# UI Changes / Functionality
*No chances to UI.*

# Testing Steps
*For example add 10 furniture to the appartment, then after that randomly remove 5 furniture from the list and exit the appartment. When entering or leaving the appartment furniture cannot be loaded or unloaded. Encoded json stored in the SQL will look like in the issue. Removing furniture in the modeler UI will also cause issues with table indexing, client side furniture table item removal has been adjusted accordingly to the server side changes. Added checks that specific entity exists when leaving appartment if furniture unload happens on an index that doesn't exist anymore.*

https://streamable.com/tg9zxx

```json
[
  {
    "label": "Old chair",
    "object": "prop_ld_farm_chair01",
    "position": { "x": -3.6913, "y": -0.3834, "z": -0.8096 },
    "rotation": { "x": 0.0, "y": -0.0, "z": 0.0 },
    "id": "967934118"
  },
  null,
  null,
  {
    "label": "Dining Table",
    "object": "v_res_fh_diningtable",
    "position": { "x": 3.8983, "y": -1.6363, "z": -1.9493 },
    "rotation": { "x": 0.0, "y": -0.0, "z": -101.99999237060549 },
    "id": "261757118"
  }
]
```
After changes stored table will have no null values
```json
[
  {
    "label": "Old chair",
    "object": "prop_ld_farm_chair01",
    "position": { "x": -3.6913, "y": -0.3834, "z": -0.8096 },
    "rotation": { "x": 0.0, "y": -0.0, "z": 0.0 },
    "id": "967934118"
  },
  {
    "label": "Dining Table",
    "object": "v_res_fh_diningtable",
    "position": { "x": 3.8983, "y": -1.6363, "z": -1.9493 },
    "rotation": { "x": 0.0, "y": -0.0, "z": -101.99999237060549 },
    "id": "261757118"
  }
]
```

- [X] Did you test the changes you made?
- [X] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [ ] Did you test your changes in multiplayer to ensure it works correctly on all clients?
