### PR TITLE
Fixing the incorrect table name in server.lua and updating the README with the solution for the properties.sql import issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,23 @@ end)
 
 10. Install the dependencies below.
 
+## Resolving the "Foreign key constraint is incorrectly formed" Issue
+
+If you come across an error such as `Foreign key constraint is incorrectly formed` while importing the `properties.sql` into your database, follow these steps to fix it.
+
+1. Open your database in HeidiSQL.
+2. Right-click on your database name and select "Edit."
+3. Locate the database collation setting take a note of it. 
+4. You will need to format the `properties.sql` file to match your database collation.
+
+If your database collation is set to `utf8mb4_general_ci`, modify the `properties.sql` file using a text editor like VSCode or in HeidiSQL's query tab. Change the last line to the following:
+
+```sql
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+```
+
+This adjustment ensures that your SQL file's character set and collation match that of your database, effectively resolving the issue.
+
 ## Item Limits System
 
 1. Choose an item you want to limit under `Config.Furniture` in under `shared/config.lua`

--- a/server/server.lua
+++ b/server/server.lua
@@ -112,7 +112,7 @@ lib.callback.register("ps-housing:cb:GetOwnedApartment", function(source, cid)
     else
         local src = source
         local Player = QBCore.Functions.GetPlayer(src)
-        local result = MySQL.query.await('SELECT * FROM apartments WHERE owner_citizenid = ? AND apartment IS NOT NULL AND apartment <> ""', { Player.PlayerData.citizenid })
+        local result = MySQL.query.await('SELECT * FROM properties WHERE owner_citizenid = ? AND apartment IS NOT NULL AND apartment <> ""', { Player.PlayerData.citizenid })
         if result[1] ~= nil then
             return result[1]
         end


### PR DESCRIPTION
# Overview
This PR should fix the issue with sql query which calls the wrong table in the db and I have added some details about the solution for the `properties.sql` import issue : Foreign key constraint is incorrectly formed!

# Details
As I described in the overview there was a problem in the server.lua (line 115) which calls wrong table : `apartments`, instead of the `properties` table.
And I have added an additional part to the readme which tells how to fix that `"Foreign key constraint is incorrectly formed"` error.

# UI Changes / Functionality
- No UI changes

# Testing Steps
- Just download the release and config it as in the readme. 
- Create a new character and see the server console.
- Make sure to use a completely wiped database. (without any previous player data.)

- [ ] Did you test the changes you made? = Yes
- [ ] Did you test core functionality of the script to ensure your changes do not regress other areas? = Yes
- [ ] Did you test your changes in multiplayer to ensure it works correctly on all clients? = Yes
