### PR TITLE
refactor: Ox Inventory Support + More End-User Notifications + Multiple Police Jobs For Raids

### DIFF
--- a/server/sv_property.lua
+++ b/server/sv_property.lua
@@ -526,9 +526,10 @@ RegisterNetEvent('ps-housing:server:raidProperty', function(property_id)
     local jobName = job.name
     local gradeAllowed = tonumber(job.grade.level) >= Config.MinGradeToRaid
     local onDuty = job.onduty
+    local raidItem = Config.RaidItem
 
     -- Check if the police officer has the "stormram" item
-    local hasStormRam = (Config.Inventory == "ox" and exports.ox_inventory:Search(src, "count", "police_stormram") > 0) or Player.Functions.GetItemByName("police_stormram")
+    local hasStormRam = (Config.Inventory == "ox" and exports.ox_inventory:Search(src, "count", raidItem) > 0) or Player.Functions.GetItemByName(raidItem)
 
     local isAllowedToRaid = PoliceJobs[jobName] and onDuty and gradeAllowed
     if isAllowedToRaid then
@@ -544,9 +545,9 @@ RegisterNetEvent('ps-housing:server:raidProperty', function(property_id)
                     if Config.Inventory == 'ox' then
                         exports.ox_inventory:RemoveItem(src, 'police_stormram', 1)
                     else
-                        Player.Functions.RemoveItem("police_stormram", 1)
-                        TriggerClientEvent("inventory:client:ItemBox", src, QBCore.Shared.Items["police_stormram"], "remove")
-                        TriggerEvent("inventory:server:RemoveItem", src, "police_stormram", 1)
+                        Player.Functions.RemoveItem(raidItem, 1)
+                        TriggerClientEvent("inventory:client:ItemBox", src, QBCore.Shared.Items[raidItem], "remove")
+                        TriggerEvent("inventory:server:RemoveItem", src, raidItem, 1)
                     end
                 end
             else

--- a/server/sv_property.lua
+++ b/server/sv_property.lua
@@ -519,34 +519,30 @@ RegisterNetEvent('ps-housing:server:raidProperty', function(property_id)
         return 
     end
 
-    local PlayerData = GetPlayerData(src)
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not Player then return end
+    local PlayerData = Player.PlayerData
     local job = PlayerData.job
     local jobName = job.name
     local gradeAllowed = tonumber(job.grade.level) >= Config.MinGradeToRaid
     local onDuty = job.onduty
 
     -- Check if the police officer has the "stormram" item
-    local hasStormRam = false
-    local stormRamIndex = nil
-    for index, item in pairs(PlayerData.items) do
-        if item.name == "police_stormram" then
-            hasStormRam = true
-            stormRamIndex = index
-            break
-        end
-    end
+    local hasStormRam = (Config.Inventory == "ox" and exports.ox_inventory:Search(src, "count", "police_stormram") > 0) or Player.Functions.GetItemByName("police_stormram")
 
-    if jobName == "police" and onDuty and gradeAllowed and hasStormRam then
+    if PoliceJobs[jobName] and onDuty and gradeAllowed and hasStormRam then
         if not property.raiding then
             local confirmRaid = lib.callback.await('ps-housing:cb:confirmRaid', src, (property.propertyData.street or property.propertyData.apartment) .. " " .. property.property_id, property_id)
             if confirmRaid == "confirm" then
                 property:StartRaid(src)
                 property:PlayerEnter(src)
                 Framework[Config.Notify].Notify(src, "Raid started", "success")
-                
+
                 -- Remove the "stormram" item from the officer's inventory
-                if stormRamIndex then
-                    table.remove(PlayerData.items, stormRamIndex)
+                if Config.Inventory == 'ox' then
+                    exports.ox_inventory:RemoveItem(src, 'police_stormram', 1)
+                else
+                    Player.Functions.RemoveItem("police_stormram", 1)
                     TriggerClientEvent("inventory:client:ItemBox", src, QBCore.Shared.Items["police_stormram"], "remove")
                     TriggerEvent("inventory:server:RemoveItem", src, "police_stormram", 1)
                 end
@@ -555,7 +551,7 @@ RegisterNetEvent('ps-housing:server:raidProperty', function(property_id)
             Framework[Config.Notify].Notify(src, "Raid in progress", "success")
             property:PlayerEnter(src)
         end
-    elseif jobName == "police" and onDuty and gradeAllowed and not hasStormRam then
+    elseif PoliceJobs[jobName] and onDuty and gradeAllowed and not hasStormRam then
         Framework[Config.Notify].Notify(src, "You need a stormram to enter", "error")
     end
 end)

--- a/server/sv_property.lua
+++ b/server/sv_property.lua
@@ -530,29 +530,40 @@ RegisterNetEvent('ps-housing:server:raidProperty', function(property_id)
     -- Check if the police officer has the "stormram" item
     local hasStormRam = (Config.Inventory == "ox" and exports.ox_inventory:Search(src, "count", "police_stormram") > 0) or Player.Functions.GetItemByName("police_stormram")
 
-    if PoliceJobs[jobName] and onDuty and gradeAllowed and hasStormRam then
-        if not property.raiding then
-            local confirmRaid = lib.callback.await('ps-housing:cb:confirmRaid', src, (property.propertyData.street or property.propertyData.apartment) .. " " .. property.property_id, property_id)
-            if confirmRaid == "confirm" then
-                property:StartRaid(src)
-                property:PlayerEnter(src)
-                Framework[Config.Notify].Notify(src, "Raid started", "success")
+    local isAllowedToRaid = PoliceJobs[jobName] and onDuty and gradeAllowed
+    if isAllowedToRaid then
+        if hasStormRam then
+            if not property.raiding then
+                local confirmRaid = lib.callback.await('ps-housing:cb:confirmRaid', src, (property.propertyData.street or property.propertyData.apartment) .. " " .. property.property_id, property_id)
+                if confirmRaid == "confirm" then
+                    property:StartRaid(src)
+                    property:PlayerEnter(src)
+                    Framework[Config.Notify].Notify(src, "Raid started", "success")
 
-                -- Remove the "stormram" item from the officer's inventory
-                if Config.Inventory == 'ox' then
-                    exports.ox_inventory:RemoveItem(src, 'police_stormram', 1)
-                else
-                    Player.Functions.RemoveItem("police_stormram", 1)
-                    TriggerClientEvent("inventory:client:ItemBox", src, QBCore.Shared.Items["police_stormram"], "remove")
-                    TriggerEvent("inventory:server:RemoveItem", src, "police_stormram", 1)
+                    -- Remove the "stormram" item from the officer's inventory
+                    if Config.Inventory == 'ox' then
+                        exports.ox_inventory:RemoveItem(src, 'police_stormram', 1)
+                    else
+                        Player.Functions.RemoveItem("police_stormram", 1)
+                        TriggerClientEvent("inventory:client:ItemBox", src, QBCore.Shared.Items["police_stormram"], "remove")
+                        TriggerEvent("inventory:server:RemoveItem", src, "police_stormram", 1)
+                    end
                 end
+            else
+                Framework[Config.Notify].Notify(src, "Raid in progress", "success")
+                property:PlayerEnter(src)
             end
         else
-            Framework[Config.Notify].Notify(src, "Raid in progress", "success")
-            property:PlayerEnter(src)
+            Framework[Config.Notify].Notify(src, "You need a stormram to perform a raid", "error")
         end
-    elseif PoliceJobs[jobName] and onDuty and gradeAllowed and not hasStormRam then
-        Framework[Config.Notify].Notify(src, "You need a stormram to enter", "error")
+    else
+        if not PoliceJobs[jobName] then
+            Framework[Config.Notify].Notify(src, "Only police officers are permitted to perform raids", "error")
+        elseif not onDuty then
+            Framework[Config.Notify].Notify(src, "You must be onduty before performing a raid", "error")
+        elseif not gradeAllowed then
+            Framework[Config.Notify].Notify(src, "You must be a higher rank before performing a raid", "error")
+        end
     end
 end)
 

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -39,7 +39,9 @@ Config.PoliceJobNames = {  -- add multiple police jobs that are allowed to raid 
 
 Config.MinGradeToRaid = 3  -- Minimum grade to raid a property
 
-Config.RaidTimer = 5-- 5 minutes
+Config.RaidTimer = 5  -- 5 minutes
+
+Config.RaidItem = "police_stormram"  -- The item required to raid a property
 
 Config.RealtorJobName = "realestate" -- Set your Real Estate job here
 


### PR DESCRIPTION
# Overview
This PR is in result of PR #106 that attempts to do the same thing and a little more. I wish for easier to read code whilst utilizing proven performant and safe methods. This will also improve the front-end user experience by notifying them of exactly what they're doing wrong. This will also allow server owners and developers to change the item required to raid properties.

# Details
This change will increase code speed along with removing the potential for data corruption.
If the end-user is using ox_inventory, they will take advantage of ox_inventory's search export instead of the slower QBCore GetItemByName player method.

Both inventories have been tested using this code and ox_inventory will even support the code even if the end-user puts the inventory on "qb" by accident. All other code has been tested by me as well.

Players will now be notified of every single thing that they're doing wrong when attempting to raid a property so they're no longer in the dark as to what the issue is.

Server owners and developers will now be able to adjust the item required in order to raid properties by going into shared/config.lua

# UI Changes / Functionality
This will eliminate the frustration of not being able to raid a house due to the multiple police job config not being connected to the job check found within the code before my change.
The code will now notify players of every reason possible as to why they're unable to raid the house other than not having the police_stormram item.
The item required to raid a property is now also adjustable by server owners and developers.

# Testing Steps
Choose an inventory of choice within shared/config.lua
Go up to the property that you wish to raid as someone who has a job that isn't within the Config.PoliceJobs list. This will trigger an error notification that you must be a police officer (You can't even access the 3rd eye target so skip this step unless you want to modify the code to allow you to have the 3rd eye target anyways).
Ensure that you are not on duty.
Attempt to raid the property whilst not onduty and it will tell you that you must be on duty to raid the apartment.
Go on duty.
Attempt to raid the apartment whilst your job's grade is lower than the value of Config.MinGradeToRaid and it will notify you that you must be of a higher rank.
Set your job's grade to that of an equivalent or higher grade than the value of Config.MinGradeToRaid.
Ensure that you DO NOT have a storm ram. Once you third-eye the house's front door it will prompt you to raid it. Due to the fact that you don't have a storm ram, it will ask you to obtain one.
Obtain a `police_stormram` item and then repeat the previous steps to ensure that you can successfully start a raid on the property.
Once you enter the house and your stormram has been removed from your inventory, your test has concluded for that inventory configuration.
Repeat all steps to test for the other Config.Inventory value.

- [YES] Did you test the changes you made?
- [YES] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [YES] Did you test your changes in multiplayer to ensure it works correctly on all clients?
