### PR TITLE
Fix for targetSrc nil error when removing owner

### DIFF
--- a/server/sv_property.lua
+++ b/server/sv_property.lua
@@ -231,12 +231,26 @@ function Property:UpdateOwner(data)
     local realtorSrc = data.realtorSrc
 
     if not realtorSrc then Debug("No Realtor Src found") return end
-    if not targetSrc then Debug("No Target Src found") return end
+    if not targetSrc or string.len(targetSrc) <= 0 then 
+        local realtor = QBCore.Functions.GetPlayer(tonumber(realtorSrc))
+
+        Debug("No Target Source found / Owner being removed.")
+
+        MySQL.update("UPDATE properties SET owner_citizenid = NULL, for_sale = 0, has_access = json_array()  WHERE property_id = @property_id", {["@property_id"] = self.property_id})
+
+        self.propertyData.owner = nil
+        self.propertyData.furnitures = {} -- to be fetched on enter
+
+        TriggerClientEvent("ps-housing:client:updateProperty", -1, "UpdateOwner", self.property_id, null)
+
+        Framework[Config.Logs].SendLog("**House Owner Removed** by: **"..realtor.PlayerData.charinfo.firstname.." "..realtor.PlayerData.charinfo.lastname.."** from "..self.property_id.."!")
+
+        Framework[Config.Notify].Notify(realtorSrc, "You have removed the Owner from this house.", "success")
+        return 
+    end
 
     local previousOwner = self.propertyData.owner
-
     local targetPlayer  = QBCore.Functions.GetPlayer(tonumber(targetSrc))
-
     local PlayerData = targetPlayer.PlayerData
     local bank = PlayerData.money.bank
     local citizenid = PlayerData.citizenid


### PR DESCRIPTION
# Overview
When removing the owner from the house, in the realtor app, You get a targetSrc error, This fixes it and removed the owner and people that have keys.

# Details
When removing the owner in the realtor app, the target returned a whitespace, this checks for the string length and the added functionality removes the owner and the people that had keys.

# UI Changes / Functionality
None.

# Testing Steps
Open the App, Check your DB, Choose a owned property, Set to for Sale, Remove the Owner ID to make it blank, it should now set the DB correctly and remove the owner.

- [x] Did you test the changes you made?
- [x] Did you test the core functionality of the script to ensure your changes do not regress other areas?
- [x] Did you test your changes in multiplayer to ensure it works correctly on all clients?
