### PR TITLE
feat: Configurable consumption of raid item

### DIFF
--- a/server/sv_property.lua
+++ b/server/sv_property.lua
@@ -541,13 +541,15 @@ RegisterNetEvent('ps-housing:server:raidProperty', function(property_id)
                     property:PlayerEnter(src)
                     Framework[Config.Notify].Notify(src, "Raid started", "success")
 
-                    -- Remove the "stormram" item from the officer's inventory
-                    if Config.Inventory == 'ox' then
-                        exports.ox_inventory:RemoveItem(src, raidItem, 1)
-                    else
-                        Player.Functions.RemoveItem(raidItem, 1)
-                        TriggerClientEvent("inventory:client:ItemBox", src, QBCore.Shared.Items[raidItem], "remove")
-                        TriggerEvent("inventory:server:RemoveItem", src, raidItem, 1)
+                    if Config.ConsumeRaidItem then
+                        -- Remove the "stormram" item from the officer's inventory
+                        if Config.Inventory == 'ox' then
+                            exports.ox_inventory:RemoveItem(src, raidItem, 1)
+                        else
+                            Player.Functions.RemoveItem(raidItem, 1)
+                            TriggerClientEvent("inventory:client:ItemBox", src, QBCore.Shared.Items[raidItem], "remove")
+                            TriggerEvent("inventory:server:RemoveItem", src, raidItem, 1)
+                        end
                     end
                 end
             else

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -43,7 +43,8 @@ Config.RaidTimer = 5  -- 5 minutes
 
 Config.RaidItem = "police_stormram"  -- The item required to raid a property
 
-Config.ConsumeRaidItem = false          -- Whether or not to consume the raid item upon successful entry
+-- If you are using ox_inventory, it is encouraged to use the consume property within data/items.lua and keeping this config option false
+Config.ConsumeRaidItem = false          -- Whether or not to consume the raid item upon successful entry.
 
 Config.RealtorJobName = "realestate" -- Set your Real Estate job here
 

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -43,6 +43,8 @@ Config.RaidTimer = 5  -- 5 minutes
 
 Config.RaidItem = "police_stormram"  -- The item required to raid a property
 
+Config.ConsumeRaidItem = false          -- Whether or not to consume the raid item upon successful entry
+
 Config.RealtorJobName = "realestate" -- Set your Real Estate job here
 
 -- Realtor Commisions based on job grade, the rest goes to the owner, if any.


### PR DESCRIPTION
# Overview
This PR allows server owners and developers to either utilize the script's item removal system when executing a raid.

# Details
In the config, I have provided a new config value that will allow server owners and developers to configure whether or not they prefer to consume the raid item upon use. I have left it disabled by default to prevent frustration from individuals that like to skim through configs or drag and drop without even looking at it.

# UI Changes / Functionality
The `shared/config.lua` file has been adjusted to include a new field **ConsumeRaidItem** that determines whether or not `server/sv_property.lua` will fully consume the item upon use. There is also a small tip that will let server owners and developers know that it's encouraged to use ox_inventory's supported consumption feature because it will make the item have durability instead.

# Testing Steps
Perform a raid on a property.
If you have **Config.ConsumeRaidItem**'s value as `true`, it should consume the raid item that's been set as **Config.RaidItem**'s value.
If you have **Config.ConsumeRaidItem**'s value as `false`, the code will not automatically remove the raid item that's been set as **Config.RaidItem**'s value.

- [YES] Did you test the changes you made?
- [YES] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [YES] Did you test your changes in multiplayer to ensure it works correctly on all clients?
