### PR TITLE
Clothing menu appears after creating character with Config.StartingApartment disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ https://github.com/complexza/ps-housing/assets/74205343/0ff26e7f-1341-45fc-8fc6-
 
 ## PAY ATTENTION TO EACH STEP. DO NOT SKIP ANY. 
 
-1. Find the following events in `qb-multicharacter` and change in server/main.lua event to: 
+1. Find the following events in `qb-multicharacter` and change events to: 
 
 `qb-multicharacter > server > main.lua`
 ```lua
@@ -107,15 +107,34 @@ RegisterNetEvent('qb-multicharacter:server:createCharacter', function(data)
         repeat
             Wait(10)
         until hasDonePreloading[src]
-        print('^2[qb-core]^7 '..GetPlayerName(src)..' has succesfully loaded!')
-        QBCore.Commands.Refresh(src)
-        TriggerClientEvent("qb-multicharacter:client:closeNUI", src)
-        newData.citizenid = QBCore.Functions.GetPlayer(src).PlayerData.citizenid
-        TriggerClientEvent('ps-housing:client:setupSpawnUI', src, newData)
-        GiveStarterItems(src)
+        if Config.StartingApartment then
+            print('^2[qb-core]^7 '..GetPlayerName(src)..' has succesfully loaded!')
+            QBCore.Commands.Refresh(src)
+            TriggerClientEvent("qb-multicharacter:client:closeNUI", src)
+            newData.citizenid = QBCore.Functions.GetPlayer(src).PlayerData.citizenid
+            TriggerClientEvent('ps-housing:client:setupSpawnUI', src, newData)
+            GiveStarterItems(src)
+        else
+            print('^2[qb-core]^7 '..GetPlayerName(src)..' has succesfully loaded!')
+            QBCore.Commands.Refresh(src)
+            TriggerClientEvent("qb-multicharacter:client:closeNUIdefault", src)
+            GiveStarterItems(src)
+        end
     end
 end)
 ```
+1.1 Replace the following:
+`qb-multicharacter > fxmanifest.lua > shared_scripts`
+```lua
+shared_scripts {
+    '@qb-core/shared/locale.lua',
+    '@ps-housing/shared/config.lua',
+    'locales/en.lua',
+    'locales/*.lua',
+    'config.lua'
+}
+```
+
 2. Find the following events in `qb-spawn` and change in client/client.lua event to: 
 
 `qb-spawn > client.lua > line 51 > 'qb-spawn:client:setupSpawns' event`


### PR DESCRIPTION
Not sure how to utilize routing buckets so didn't use them at all, but it's a start

# Overview
This PR allows you to customize your character after creating it even if Config.StartingApartment is disabled (fixes #121)

# Details
Just qb-multicharacter changes, that's why only the readme is changed

# UI Changes / Functionality
After:
![image](https://github.com/Project-Sloth/ps-housing/assets/90502234/e47a8362-7c9f-4470-94c2-da6742a7f4bd)


# Testing Steps
Create a new character, select a spawn if you have any then the menu will show up.
Not sure if this bugs the apartment spawning, haven't tested it. It should not though
- [X] Did you test the changes you made?
- [ ] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [ ] Did you test your changes in multiplayer to ensure it works correctly on all clients?
