### PR TITLE
Added reload to furnituries after closing menu / moving furniture. Th…

### DIFF
--- a/client/cl_property.lua
+++ b/client/cl_property.lua
@@ -554,6 +554,7 @@ end
 local function findFurnitureDifference(new, old)
     local added = {}
     local removed = {}
+    local edited = {}
 
     for i = 1, #new do
         local found = false
@@ -581,7 +582,13 @@ local function findFurnitureDifference(new, old)
         end
     end
 
-    return added, removed
+    for i = 1, #new do
+        if new[i].movedObject then
+            edited[#edited + 1] = new[i]
+        end
+    end
+
+    return added, removed, edited
 end
 
 -- I think this whole furniture sync is a bit shit, but I cbf thinking 
@@ -589,7 +596,7 @@ function Property:UpdateFurnitures(newFurnitures)
     if not self.inProperty then return end
 
     local oldFurnitures = self.propertyData.furnitures
-    local added, removed = findFurnitureDifference(newFurnitures, oldFurnitures)
+    local added, removed, edited = findFurnitureDifference(newFurnitures, oldFurnitures)
 
     for i = 1, #added do
         local furniture = added[i]
@@ -600,8 +607,27 @@ function Property:UpdateFurnitures(newFurnitures)
         local furniture = removed[i]
         self:UnloadFurniture(furniture)
     end
+    
+    for i = 1, #edited do
+        local furniture = edited[i]
+        self:UnloadFurniture(furniture)
+        self:LoadFurniture(furniture)
+    end
 
-    self.propertyData.furnitures = newFurnitures
+    local furnitures = {}
+
+    for i = 1, #newFurnitures do
+        furnitures[i] = {
+            id = newFurnitures[i].id,
+            label = newFurnitures[i].label,
+            object = newFurnitures[i].object,
+            position = newFurnitures[i].position,
+            rotation = newFurnitures[i].rotation,
+            type = newFurnitures[i].type
+        }
+    end
+
+    self.propertyData.furnitures = furnitures
 
     Modeler:UpdateFurnitures()
 end

--- a/client/modeler.lua
+++ b/client/modeler.lua
@@ -342,6 +342,7 @@ Modeler = {
             position = offsetPos,
             rotation = newRot,
             type = item.type,
+            movedObject = true
         }
 
         TriggerServerEvent("ps-housing:server:updateFurniture", self.property_id, newFurniture)

--- a/server/sv_property.lua
+++ b/server/sv_property.lua
@@ -135,10 +135,23 @@ function Property:StartRaid()
 end
 
 function Property:UpdateFurnitures(furnitures)
-    self.propertyData.furnitures = furnitures
+    local newfurnitures = {}
+
+    for i = 1, #furnitures do
+        newfurnitures[i] = {
+            id = furnitures[i].id,
+            label = furnitures[i].label,
+            object = furnitures[i].object,
+            position = furnitures[i].position,
+            rotation = furnitures[i].rotation,
+            type = furnitures[i].type
+        }
+    end
+
+    self.propertyData.furnitures = newfurnitures
 
     MySQL.update("UPDATE properties SET furnitures = @furnitures WHERE property_id = @property_id", {
-        ["@furnitures"] = json.encode(furnitures),
+        ["@furnitures"] = json.encode(newfurnitures),
         ["@property_id"] = self.property_id
     })
 


### PR DESCRIPTION
Fixes problem after moving objects/furniture.

# Overview
This PR fixes a problem on prop collisions and using storage or wardrobe after furniture is moved.

# Details
Making variable to furniture data table named movedObject for moving furniture for function findFurnitureDifference and Property:UpdateFurnitures that helps to compare values and reload the furniture when you stop placement/moving it. That movedObject variable is removed in database querys and be removed on client data/table after reload furniture.

# UI Changes / Functionality
**Before changes**
![before](https://github.com/Project-Sloth/ps-housing/assets/53654750/65cdab9a-27bf-47d0-8bfa-6e5058a0af7b)

**After changes**
![after](https://github.com/Project-Sloth/ps-housing/assets/53654750/95577335-caec-4b91-9249-4d05af4eaf7c)

# Testing Steps
Tested move objects, checked collisions and targetting for storage box or wardrobe. Printed variables and checked database values for furniture data table. Tested place new furnitures and remove furnitures.

- [x] Did you test the changes you made?
- [x] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [x] Did you test your changes in multiplayer to ensure it works correctly on all clients?
