### PR TITLE
FIX: Grab newPos and newRot before object delete

### DIFF
--- a/client/modeler.lua
+++ b/client/modeler.lua
@@ -328,15 +328,14 @@ Modeler = {
     -- everytime "Stop Placement" is pressed on an owned object, it will update the furniture 
     -- maybe should do it all at once when the user leaves the menu????
     UpdateFurniture = function (self, item)
+        local newPos = GetEntityCoords(item.entity)
+        local newRot = GetEntityRotation(item.entity)
         DeleteEntity(item.entity)
 
         local hash = GetHashKey(item.object)
         lib.requestModel(hash)
 
         if not IsModelInCdimage(hash) then return end
-
-        local newPos = GetEntityCoords(item.entity)
-        local newRot = GetEntityRotation(item.entity)
 
         item.entity = CreateObject(GetHashKey(item.object), newPos.x, newPos.y, newPos.z, false, true, false)
         SetEntityRotation(item.entity, newRot.x, newRot.y, newRot.z)


### PR DESCRIPTION
# Overview
Fix for issue #168 - Furniture position bug

# Details
Players unable to change furniture position after purchase, otherwise results in position of object returning 0,0,0
This is caused by the object being deleted before obtaining the new coordinates and rotation. These are now captured before object delete in client/modeler.lua

# UI Changes / Functionality
None

# Testing Steps
Followed the steps listed in #168, and confirmed the issue is no longer present.

- [x] Did you test the changes you made?
- [x] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [x] Did you test your changes in multiplayer to ensure it works correctly on all clients?
