### PR TITLE
Added event update for spawnLastLocation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,31 @@ RegisterNetEvent('qb-multicharacter:server:createCharacter', function(data)
     end
 end)
 ```
+
+`qb-multicharacter > client > main.lua`
+```lua
+RegisterNetEvent('qb-multicharacter:client:spawnLastLocation', function(coords, cData)
+    local ped = PlayerPedId()
+    SetEntityCoords(ped, coords.x, coords.y, coords.z)
+    SetEntityHeading(ped, coords.w)
+    FreezeEntityPosition(ped, false)
+    SetEntityVisible(ped, true)
+
+    TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
+    TriggerEvent('QBCore:Client:OnPlayerLoaded')
+
+    --If the player was in a house previously, spawn back in
+    local insideMeta = QBCore.Functions.GetPlayerData().metadata["inside"]
+    if insideMeta.property_id ~= nil then
+        local property_id = insideMeta.property_id
+        TriggerServerEvent('ps-housing:server:enterProperty', tostring(property_id))
+    end
+
+    --Finish fade in and etc.
+    Wait(2000)
+    DoScreenFadeIn(250)
+end)
+```
 ### 2. Find the following events in `qb-spawn` and change in client/client.lua event to: 
 
 `qb-spawn > client.lua > line 51 > 'qb-spawn:client:setupSpawns' event`

--- a/client/modeler.lua
+++ b/client/modeler.lua
@@ -328,15 +328,14 @@ Modeler = {
     -- everytime "Stop Placement" is pressed on an owned object, it will update the furniture 
     -- maybe should do it all at once when the user leaves the menu????
     UpdateFurniture = function (self, item)
+        local newPos = GetEntityCoords(item.entity)
+        local newRot = GetEntityRotation(item.entity)
         DeleteEntity(item.entity)
 
         local hash = GetHashKey(item.object)
         lib.requestModel(hash)
 
         if not IsModelInCdimage(hash) then return end
-
-        local newPos = GetEntityCoords(item.entity)
-        local newRot = GetEntityRotation(item.entity)
 
         item.entity = CreateObject(GetHashKey(item.object), newPos.x, newPos.y, newPos.z, false, true, false)
         SetEntityRotation(item.entity, newRot.x, newRot.y, newRot.z)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -43,5 +43,14 @@ files {
 this_is_a_map 'yes'
 data_file 'DLC_ITYP_REQUEST' 'starter_shells_k4mb1.ytyp'
 
+-- Fix for players not being able to load into houses
+data_file 'DLC_ITYP_REQUEST' 'starter_shells_k4mb1.ytyp'
+data_file 'DLC_ITYP_REQUEST' 'x64c:/levels/gta5/interiors/int_props/int_corporate.rpf/int_corporate.ytyp'
+data_file 'DLC_ITYP_REQUEST' 'x64c:/levels/gta5/interiors/int_props/int_industrial.rpf/int_industrial.ytyp'
+data_file 'DLC_ITYP_REQUEST' 'x64c:/levels/gta5/interiors/int_props/int_lev_des.rpf/int_lev_des.ytyp'
+data_file 'DLC_ITYP_REQUEST' 'x64c:/levels/gta5/interiors/int_props/int_residential.rpf/int_residential.ytyp'
+data_file 'DLC_ITYP_REQUEST' 'x64c:/levels/gta5/interiors/int_props/int_retail.rpf/int_retail.ytyp'
+data_file 'DLC_ITYP_REQUEST' 'x64c:/levels/gta5/interiors/int_props/int_services.rpf/int_services.ytyp'
+
 file 'stream/**.ytyp'
 data_file 'DLC_ITYP_REQUEST' 'stream/**.ytyp'


### PR DESCRIPTION
# Overview
spawnLastLocation was not supporting house checks, resulting in players falling through the map if Config.SkipSelection was enabled in qb-multicharacter

# Details
Simple update to README with the property_id checks in place for easy implementation

# UI Changes / Functionality
Functionality: Checks for property_id not being nil, and placing into property.
No video as similar code to qb-spawn with a slight addition

# Testing Steps
*Provide a list of repro steps on how to test that your changes are valid.*

- [x] Did you test the changes you made?
- [x] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [x] Did you test your changes in multiplayer to ensure it works correctly on all clients?
