### PR TITLE
Fix: Infinite loading screen with decorated houses

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -43,5 +43,14 @@ files {
 this_is_a_map 'yes'
 data_file 'DLC_ITYP_REQUEST' 'starter_shells_k4mb1.ytyp'
 
+-- Fix for "stuck in black loading screen"
+data_file 'DLC_ITYP_REQUEST' 'x64c:/levels/gta5/interiors/int_props/int_corporate.rpf/int_corporate.ytyp'
+data_file 'DLC_ITYP_REQUEST' 'x64c:/levels/gta5/interiors/int_props/int_industrial.rpf/int_industrial.ytyp'
+data_file 'DLC_ITYP_REQUEST' 'x64c:/levels/gta5/interiors/int_props/int_lev_des.rpf/int_lev_des.ytyp'
+data_file 'DLC_ITYP_REQUEST' 'x64c:/levels/gta5/interiors/int_props/int_residential.rpf/int_residential.ytyp'
+data_file 'DLC_ITYP_REQUEST' 'x64c:/levels/gta5/interiors/int_props/int_retail.rpf/int_retail.ytyp'
+data_file 'DLC_ITYP_REQUEST' 'x64c:/levels/gta5/interiors/int_props/int_services.rpf/int_services.ytyp'
+
+
 file 'stream/**.ytyp'
 data_file 'DLC_ITYP_REQUEST' 'stream/**.ytyp'

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -51,6 +51,5 @@ data_file 'DLC_ITYP_REQUEST' 'x64c:/levels/gta5/interiors/int_props/int_resident
 data_file 'DLC_ITYP_REQUEST' 'x64c:/levels/gta5/interiors/int_props/int_retail.rpf/int_retail.ytyp'
 data_file 'DLC_ITYP_REQUEST' 'x64c:/levels/gta5/interiors/int_props/int_services.rpf/int_services.ytyp'
 
-
 file 'stream/**.ytyp'
 data_file 'DLC_ITYP_REQUEST' 'stream/**.ytyp'


### PR DESCRIPTION
# Overview
As per last few days in #support, myself and a few others have been encountering infinite loading screen when loading into a house that has furniture placed. Common issue we saw was the model was failing to load, and this simply fixes it.

# Details
During debugging, I noticed IsModelInCdimage() and IsModelValid() was returning false for certain house objects in random spots of the map. I managed to track down that the ytyp for specific objects was not loaded within those areas - bypass would be to set the YTYP as permament as per method included in the changes.

# UI Changes / Functionality
See fxmanifest.lua to see fix

# Testing Steps
1. Check if a model exists by using IsModelValid or IsModelInCdimage
2. Fly around the map until it turns false
3. You replicated the issue.

- [x] Did you test the changes you made?
- [x] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [x] Did you test your changes in multiplayer to ensure it works correctly on all clients?
