### PR TITLE
Fix for #199 | Proper Furniture Unloading

### DIFF
--- a/client/cl_property.lua
+++ b/client/cl_property.lua
@@ -486,9 +486,10 @@ function Property:UnloadFurniture(furniture, index)
         end
     end
 
-    if index and self.furnitureObjs?[index] then
-        table.remove(self.furnitureObjs, index)
-    else 
+    SetEntityAsMissionEntity(entity, true, true)
+    DeleteEntity(entity)
+
+    if not index then
         for i = 1, #self.furnitureObjs do
             if self.furnitureObjs[i]?.id and furniture?.id and self.furnitureObjs[i].id == furniture.id then
                 table.remove(self.furnitureObjs, i)
@@ -496,8 +497,6 @@ function Property:UnloadFurniture(furniture, index)
             end
         end
     end
-
-    DeleteObject(entity)
 end
 
 function Property:UnloadFurnitures()


### PR DESCRIPTION
# Overview
*Provide a brief overview of the purpose of this pull request*
Fixes furniture unloading when leaving property.
# Details
So, as I understood, once table.remove is used and entry is actually removed, leftovers in table shifts, thus changing the indexes. As a result, we do not iterate through all the furniture.

# UI Changes / Functionality
/

# Testing Steps
Enter other player's property with placed furniture.
Leave the property and enter yours.

- [YES] Did you test the changes you made?
- [YES] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [YES] Did you test your changes in multiplayer to ensure it works correctly on all clients?
