### PR TITLE
fix(ps-housing): Fix garages for has_access

### DIFF
--- a/client/cl_property.lua
+++ b/client/cl_property.lua
@@ -157,7 +157,7 @@ end
 function Property:RegisterGarageZone()
     if not next(self.propertyData.garage_data) then return end
 
-    if not (self.has_access or self.owner) or not self.owner then
+    if not self.has_access and not self.owner then
         return
     end
 


### PR DESCRIPTION
# Overview
*Fix for garage polyzones not creating for people on adding citizenid to the has_access column*

# Details
*So I've been using this script for a server that I'm working on and people who has keys to the houses cannot access the garage and I figured that the polyzones were not being registered and was able to fix it.*

- [✔] Did you test the changes you made?
- [✔] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [✔] Did you test your changes in multiplayer to ensure it works correctly on all clients?
