### PR TITLE
Tweak removeOwnedItem within modeler.lua to use ox_inv

### DIFF
--- a/client/modeler.lua
+++ b/client/modeler.lua
@@ -587,7 +587,7 @@ Modeler = {
     RemoveOwnedItem = function (self, data)
         if data.type == 'storage' then
             local property = Property.Get(self.property_id).storageTarget[data.entity]
-            local hasItems = Framework[Config.Radial].inventoryHasItems(property)
+            local hasItems = Framework[Config.Inventory].inventoryHasItems(property)
             if hasItems then Framework[Config.Notify].Notify('Stash is not empty', 'error') return end
         end
         local item = data

--- a/server/server.lua
+++ b/server/server.lua
@@ -192,7 +192,7 @@ end)
 
 lib.callback.register("ps-housing:cb:inventoryHasItems", function(source, name, isOx)
     if isOx then
-        local items = exports.ox_inventory:GetInventoryItems(name)
+        local items = #exports.ox_inventory:GetInventoryItems(name)
         return items and items > 0
     end
     local query = lib.checkDependency('qb-inventory', '2.0.0') and 'SELECT items FROM inventories WHERE identifier = ?' or 'SELECT items FROM stashitems WHERE stash = ?'


### PR DESCRIPTION
# Overview
Small fix to use Config.Inventory instead of Config.Radial within client modeler.lua when removing storage items from your property, allows you to use ox_inventory for inventories, and qb-radialmenu for the radial menus independently.

# Testing Steps
Remove a piece of storage furniture with an item in it on ox_inventory and qb-radialmenu.
Config.Inventory needs to be "ox"