### PR TITLE
Convert property id to string

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -122,6 +122,7 @@ function RegisterProperty(propertyData, preventEnter, source)
         Wait(1000)
     end
 
+    id = tostring(id)
     propertyData.property_id = id
     PropertiesTable[id] = Property:new(propertyData)
 


### PR DESCRIPTION


# Overview
Fix #258 
This change restores the conversion of id to a string in the RegisterProperty function. The conversion was previously removed, but this update reintroduces it to prevent potential issues with property identifier handling

# Details
Converting id to a string ensures consistent and reliable usage of property IDs within PropertiesTable and propertyData. This reversion addresses problems introduced by the previous removal of this conversion

# Testing Steps
*Provide a list of repro steps on how to test that your changes are valid.*

- [x] Did you test the changes you made?
- [x] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [ ] Did you test your changes in multiplayer to ensure it works correctly on all clients?
