### PR TITLE
ps-realtor: full user interface overhaul additional fixes

### DIFF
--- a/README - INSTALL INSTRUCTIONS/QBCore/properties_unsigned_price.sql
+++ b/README - INSTALL INSTRUCTIONS/QBCore/properties_unsigned_price.sql
@@ -1,0 +1,2 @@
+UPDATE `properties` SET `price` = 0 WHERE `price` < 0;
+ALTER TABLE `properties` MODIFY COLUMN `price` INT(11) UNSIGNED NOT NULL DEFAULT '0';

--- a/README - INSTALL INSTRUCTIONS/QBOX/properties_unsigned_price.sql
+++ b/README - INSTALL INSTRUCTIONS/QBOX/properties_unsigned_price.sql
@@ -1,0 +1,2 @@
+UPDATE `properties` SET `price` = 0 WHERE `price` < 0;
+ALTER TABLE `properties` MODIFY COLUMN `price` INT(11) UNSIGNED NOT NULL DEFAULT '0';

--- a/client/cl_property.lua
+++ b/client/cl_property.lua
@@ -879,7 +879,7 @@ function Property:UpdateOwner(newOwner)
 end
 
 function Property:UpdateImgs(newImgs)
-    self.propertyData.imgs = newImgs
+    self.propertyData.extra_imgs = newImgs
 end
 
 function Property:UpdateDoor(newDoor, newStreet, newRegion)

--- a/server/sv_property.lua
+++ b/server/sv_property.lua
@@ -404,7 +404,7 @@ function Property:UpdateImgs(data)
     local imgs = data.imgs
     local realtorSrc = data.realtorSrc
 
-    self.propertyData.imgs = imgs
+    self.propertyData.extra_imgs = imgs
 
     MySQL.update("UPDATE properties SET extra_imgs = @extra_imgs WHERE property_id = @property_id", {
         ["@extra_imgs"] = json.encode(imgs),

--- a/server/sv_property.lua
+++ b/server/sv_property.lua
@@ -329,11 +329,6 @@ function Property:UpdateOwner(data)
     local bank = PlayerData.money.bank
     local citizenid = PlayerData.citizenid
 
-    self:addMloDoorsAccess(citizenid)
-    if self.propertyData.shell == 'mlo' and DoorResource == 'qb' then
-        Framework[Config.Notify].Notify(targetSrc, "Go far away and come back for the door to update and open/close.", "error")
-    end
-
     if self.propertyData.owner == citizenid then
         Framework[Config.Notify].Notify(targetSrc, "You already own this property", "error")
         Framework[Config.Notify].Notify(realtorSrc, "Client already owns this property", "error")
@@ -380,6 +375,11 @@ function Property:UpdateOwner(data)
     end
     
     realtor.Functions.AddMoney('bank', commission, "Commission from Property: " .. self.propertyData.street .. " " .. self.property_id)
+
+    self:addMloDoorsAccess(citizenid)
+    if self.propertyData.shell == 'mlo' and DoorResource == 'qb' then
+        Framework[Config.Notify].Notify(targetSrc, "Go far away and come back for the door to update and open/close.", "error")
+    end
 
     self.propertyData.owner = citizenid
 

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -69,9 +69,6 @@ Config.Commissions = {
 -- Set this value to false if you don't want to assign a starting apartment.
 Config.StartingApartment = true
 
---- With this enabled, the customizer will open when starting apartment is false.
-Config.ShowCustomizerWhenNoStartingApartment = true
-
 Config.Apartments = {
     ["Integrity Way"] = {
         label = "Integrity Way",


### PR DESCRIPTION
# Overview

The main purpose of this pull request is to fix any issues that stood out to me during the testing of the user interface overhaul of ps-realtor.

# Details

- Fix "imgs" key being set instead of "extra_imgs" when editing/adding or removing property images in ps-realtor through UpdateImgs event.
- Fix prematurely granting a potential buyer access to an MLO interior which uses ox-doorlock before the purchase has even been confirmed
- Remove an unused config option that has 0 references in the codebase `ShowCustomizerWhenNoStartingApartment`
  - If this is used somewhere please let me know and i'll revert it
- Change `price` column to be an unsigned integer, this prevents negative values being stored and doubles the available pricing amount
  - Don't think this is completely necessary, it's a database change, I've added sql script to be ran after the initial one which alters the column for existing setup, without migrations this is probably the best I can do.

# UI Changes / Functionality
- No UI changes, shouldn't affect existing functionality other than allowing higher prices properties I guess.

# Testing Steps

- [x] Did you test the changes you made?
- [x] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [x] Did you test your changes in multiplayer to ensure it works correctly on all clients?

- Run the additional sql script after the initial one (or apply to existing setup)
- Use ps-realtor to add/delete/change images