### PR TITLE
Update README.md (Capitalization issues)

### DIFF
--- a/README - INSTALL INSTRUCTIONS/QBOX/README.md
+++ b/README - INSTALL INSTRUCTIONS/QBOX/README.md
@@ -299,7 +299,7 @@ end
 
 head to qbx_properties/config/shared.lua and replace this table with this
 ```lua
-ApartmentOptions = {
+apartmentOptions = {
     {
         interior = 'DellPerroHeightsApt4',
         label = 'Fantastic Plaza',


### PR DESCRIPTION




# Overview

Table calling nil on length as the table is capitalized. The table should be as shown below: `apartmentOptions` instead of `ApartmentOptions`

RegisterNetEvent('apartments:client:setupSpawnUI', function()
    if #sharedConfig.apartmentOptions == 1 then

# Details
Capitalization of the table in our readme is breaking the qbx_properties script and not allowing ps-housing to start properly. adjusting this capitalization corrects this issue.

# Testing Steps
*Provide a list of repro steps on how to test that your changes are valid.*

- [ YES ] Did you test the changes you made?
- [ YES  ] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [ YES  ] Did you test your changes in multiplayer to ensure it works correctly on all clients?
