### PR TITLE
Fix qbox readme to check for property_id

### DIFF
--- a/README - INSTALL INSTRUCTIONS/QBCore/README.md
+++ b/README - INSTALL INSTRUCTIONS/QBCore/README.md
@@ -61,8 +61,8 @@ RegisterNetEvent('qb-multicharacter:client:spawnLastLocation', function(coords, 
     local PlayerData = QBCore.Functions.GetPlayerData()
     local insideMeta = PlayerData.metadata["inside"]
     DoScreenFadeOut(500)
-    if insideMeta.propertyId then
-        TriggerServerEvent('ps-housing:server:enterProperty', tostring(insideMeta.propertyId))
+    if insideMeta.property_id then
+        TriggerServerEvent('ps-housing:server:enterProperty', tostring(insideMeta.property_id))
     else
         SetEntityCoords(ped, coords.x, coords.y, coords.z)
         SetEntityHeading(ped, coords.w)

--- a/README - INSTALL INSTRUCTIONS/QBOX/README.md
+++ b/README - INSTALL INSTRUCTIONS/QBOX/README.md
@@ -64,14 +64,12 @@ local function spawnLastLocation()
     }) end)
 
     local insideMeta = QBX.PlayerData.metadata.inside
-    if insideMeta.propertyId then
-        TriggerServerEvent('ps-housing:server:enterProperty', tostring(insideMeta.propertyId))
+    if insideMeta.property_id then
+        TriggerServerEvent('ps-housing:server:enterProperty', tostring(insideMeta.property_id))
     end
 
     TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
     TriggerEvent('QBCore:Client:OnPlayerLoaded')
-    -- TriggerServerEvent('qb-houses:server:SetInsideMeta', 0, false)
-    -- TriggerServerEvent('qb-apartments:server:SetInsideMeta', 0, 0, false)
 
     while not IsScreenFadedIn() do
         Wait(0)


### PR DESCRIPTION
# Overview
Updates the QBOX and QBCore setup instructions to use correct variable name.

# Details
The docs incorrectly say to check `insideMeta.propertyId` when it should be using `insideMeta.property_id`.

The correct value that is stored in the DB is `property_id`.


# UI Changes / Functionality
N/A

# Testing Steps
N/A

- [ ] Did you test the changes you made?
- [ ] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [ ] Did you test your changes in multiplayer to ensure it works correctly on all clients?
